### PR TITLE
Add support for background color retrieved from Xresources

### DIFF
--- a/src/x11.cpp
+++ b/src/x11.cpp
@@ -7,6 +7,29 @@
 #include <stdexcept>
 
 #include <X11/Xatom.h>
+#include <X11/Xresource.h>
+
+int getXresourceColor(const char* color, Display* display_)
+{
+    XrmInitialize();
+    char* resource_manager = XResourceManagerString(display_);
+    if (!resource_manager) {
+        return -1;
+    }
+
+    XrmDatabase db = XrmGetStringDatabase(resource_manager);
+    if (!db) {
+        return -1;
+    }
+
+    XrmValue value;
+    char *type;
+    if (XrmGetResource(db, color, "", &type, &value)) {
+        return strtol(value.addr + 1, NULL, 16); // first char is '#'
+    } else {
+        return -1;
+    }
+}
 
 x11::~x11()
 {
@@ -67,8 +90,12 @@ void x11::create(size_t border)
     height_ = attr.height - border * 2;
     depth_ = attr.depth;
 
+    int colorbg = getXresourceColor("picterm.background", display_);
+    if (colorbg == -1) {
+        colorbg = 0;
+    }
     // create overlay window
-    wnd_ = XCreateSimpleWindow(display_, parent_, border, border, width_, height_, 0, 0, 0);
+    wnd_ = XCreateSimpleWindow(display_, parent_, border, border, width_, height_, 0, 0, colorbg);
 
     const int screen = DefaultScreen(display_);
     gc_ = XCreateGC(display_, wnd_, 0, nullptr);

--- a/src/x11.cpp
+++ b/src/x11.cpp
@@ -9,28 +9,6 @@
 #include <X11/Xatom.h>
 #include <X11/Xresource.h>
 
-int getXresourceColor(const char* color, Display* display_)
-{
-    XrmInitialize();
-    char* resource_manager = XResourceManagerString(display_);
-    if (!resource_manager) {
-        return -1;
-    }
-
-    XrmDatabase db = XrmGetStringDatabase(resource_manager);
-    if (!db) {
-        return -1;
-    }
-
-    XrmValue value;
-    char *type;
-    if (XrmGetResource(db, color, "", &type, &value)) {
-        return strtol(value.addr + 1, NULL, 16); // first char is '#'
-    } else {
-        return -1;
-    }
-}
-
 x11::~x11()
 {
     if (!parent_title_.empty()) {
@@ -90,7 +68,7 @@ void x11::create(size_t border)
     height_ = attr.height - border * 2;
     depth_ = attr.depth;
 
-    int colorbg = getXresourceColor("picterm.background", display_);
+    int colorbg = getXresourceColor("picterm.background");
     if (colorbg == -1) {
         colorbg = 0;
     }
@@ -187,4 +165,26 @@ void x11::redraw() const
     expose.type = Expose;
     expose.xexpose.window = wnd_;
     XSendEvent(display_, wnd_, False, ExposureMask, &expose);
+}
+
+int x11::getXresourceColor(const char* color) const
+{
+    XrmInitialize();
+    char* resource_manager = XResourceManagerString(display_);
+    if (!resource_manager) {
+        return -1;
+    }
+
+    XrmDatabase db = XrmGetStringDatabase(resource_manager);
+    if (!db) {
+        return -1;
+    }
+
+    XrmValue value;
+    char *type;
+    if (XrmGetResource(db, color, "", &type, &value)) {
+        return strtol(value.addr + 1, NULL, 16); // first char is '#'
+    } else {
+        return -1;
+    }
 }

--- a/src/x11.hpp
+++ b/src/x11.hpp
@@ -88,6 +88,7 @@ private:
      * @brief Send expose event to redraw the window.
      */
     void redraw() const;
+    int getXresourceColor(const char* color) const;
 
 private:
     /** @brief X11 display. */


### PR DESCRIPTION
I wanted to add this functionality, so I did a little research and added this code segment. The style may not suit your preferences, but you can modify it accordingly. It seems to be working just right for me.

Having the `picterm.background` resource set, it selects that and ignores any other more general `background` resource. 
If the `picterm.background` resource is not  set, then it selects the more general `*.background` that should be present. 
In any other case the default `black` color is used.