### PR TITLE
Act correctly on the window after resizing

### DIFF
--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -41,6 +41,7 @@ void viewer::refresh()
     }
 
     // recalculate position of image on window
+    wnd_.updateWindowAttributes(border);
     ssize_t img_x;
     ssize_t img_y;
     const size_t wnd_w = wnd_.width();
@@ -112,6 +113,7 @@ bool viewer::calc_scale(scale_op op)
 
     case scale_op::optimal:
         // 100% or less to fit the window
+        wnd_.updateWindowAttributes(border);
         scale = 100;
         if (wnd_.width() < img_.width) {
             scale = 100 * (1.0f / (static_cast<float>(img_.width) / wnd_.width()));
@@ -145,6 +147,7 @@ void viewer::change_scale(size_t sc)
 
 void viewer::change_position(move_op mv)
 {
+    wnd_.updateWindowAttributes(border);
     const size_t wnd_w = wnd_.width();
     const size_t wnd_h = wnd_.height();
     const size_t img_w = wnd_.img_w();

--- a/src/x11.cpp
+++ b/src/x11.cpp
@@ -62,11 +62,7 @@ void x11::create(size_t border)
         }
     }
 
-    XWindowAttributes attr;
-    XGetWindowAttributes(display_, parent_, &attr);
-    width_ = attr.width - border * 2;
-    height_ = attr.height - border * 2;
-    depth_ = attr.depth;
+    updateWindowAttributes(border);
 
     int colorbg = getXresourceColor("picterm.background");
     if (colorbg == -1) {
@@ -156,6 +152,15 @@ void x11::run(key_handler_fn cb, bool exit_unfocus) const
             break;
         }
     }
+}
+
+void x11::updateWindowAttributes(size_t border)
+{
+    XWindowAttributes attr;
+    XGetWindowAttributes(display_, parent_, &attr);
+    width_ = attr.width - border * 2;
+    height_ = attr.height - border * 2;
+    depth_ = attr.depth;
 }
 
 void x11::redraw() const

--- a/src/x11.hpp
+++ b/src/x11.hpp
@@ -69,6 +69,8 @@ public:
      */
     void run(key_handler_fn cb, bool exit_unfocus) const;
 
+    void updateWindowAttributes(size_t border);
+
     /** @brief Get width of the window. */
     inline size_t width() const { return width_; }
     /** @brief Get height of the window. */


### PR DESCRIPTION
We have to update the window attributes before executing actions like scaling and moving, because the current version blocks some of them having knowledge for the old dimensions.

Example: Image is at optimal scale and I make the window smaller. I want to be able to hit `Backspace` and make it optimal for the new window dimensions. With this patch this is possible. 

The places where this has to happen is before every reference to `width_`, `height_` and `depth_` of the `wnd_` of type `x11`, which all reside in `viewer.cpp`